### PR TITLE
Syntax error in the rebar.config.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
   ]}.
 {deps, [
    {lfe, ".*", {git, "git://github.com/rvirding/lfe.git", {tag, "v0.10.0"}}},
-   {lutil, ".*", {git, "git://github.com/lfex/lutil.git", {tag, "0.6.67}}},
+   {lutil, ".*", {git, "git://github.com/lfex/lutil.git", {tag, "0.6.7"}}},
    {ltest, ".*", {git, "git://github.com/lfex/ltest.git", {tag, "0.6.4"}}},
    {yaws, ".*", {git, "git://github.com/klacke/yaws.git", {tag, "yaws-2.0.1"}}}
   ]}.


### PR DESCRIPTION
I encountered the following error when I tried to compile the library.

```
Getting dependencies ...
ERROR: Failed to load ./lfest/rebar.config: {error,
                                                                        {11,
                                                                         erl_scan,
                                                                         {string,
                                                                          34,
                                                                          "}}}\n  ]}.\n"}}}
make: *** [get-deps] Error 1
```
